### PR TITLE
Use donating endpoints for donation

### DIFF
--- a/apps/sel4test-tests/src/tests/faults.c
+++ b/apps/sel4test-tests/src/tests/faults.c
@@ -1013,8 +1013,8 @@ static int test_timeout_fault_nested_servers(env_t env)
     seL4_Word server_badge = 2;
     seL4_Word proxy_badge = 3;
 
-    seL4_CPtr client_proxy_ep = vka_alloc_endpoint_leaky(&env->vka);
-    seL4_CPtr proxy_server_ep = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr client_proxy_ep = vka_alloc_donating_endpoint_leaky(&env->vka);
+    seL4_CPtr proxy_server_ep = vka_alloc_donating_endpoint_leaky(&env->vka);
     seL4_CPtr tfep = vka_alloc_endpoint_leaky(&env->vka);
     seL4_CPtr proxy_ro = vka_alloc_reply_leaky(&env->vka);
     seL4_CPtr server_ro = vka_alloc_reply_leaky(&env->vka);

--- a/apps/sel4test-tests/src/tests/ipc.c
+++ b/apps/sel4test-tests/src/tests/ipc.c
@@ -551,14 +551,14 @@ static int single_client_server_chain_test(env_t env, int fastpath, int prio_dif
     create_helper_thread(env, &client);
     set_helper_priority(env, &client, client_prio);
 
-    seL4_CPtr receive_endpoint = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr receive_endpoint = vka_alloc_donating_endpoint_leaky(&env->vka);
     seL4_CPtr first_endpoint = receive_endpoint;
 
     /* create proxies */
     for (int i = 0; i < num_proxies; i++) {
         int prio = server_prio + (prio_diff * i);
         proxy_state[i] = 0;
-        seL4_CPtr call_endpoint = vka_alloc_endpoint_leaky(&env->vka);
+        seL4_CPtr call_endpoint = vka_alloc_donating_endpoint_leaky(&env->vka);
         create_helper_thread(env, &proxies[i]);
         set_helper_priority(env, &proxies[i], prio);
         ZF_LOGD("Start proxy\n");
@@ -678,7 +678,7 @@ static int test_transfer_on_reply(env_t env)
     volatile int state = 1;
     helper_thread_t client, server;
 
-    seL4_CPtr endpoint = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr endpoint = vka_alloc_donating_endpoint_leaky(&env->vka);
     create_helper_thread(env, &client);
     create_helper_thread(env, &server);
 
@@ -969,7 +969,7 @@ static int test_fault_handler_donated_sc(env_t env)
     helper_thread_t handler, faulter;
     void *vaddr = NULL;
 
-    seL4_CPtr endpoint = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr endpoint = vka_alloc_donating_endpoint_leaky(&env->vka);
     reservation_t res = vspace_reserve_range(&env->vspace, PAGE_SIZE_4K, seL4_AllRights, 1, &vaddr);
     test_check(vaddr != NULL);
 
@@ -1033,7 +1033,7 @@ static void ipc22_server_fn(seL4_CPtr init_ep, seL4_CPtr reply_cap)
 static void ipc22_stack_spawner_fn(env_t env, seL4_CPtr endpoint, int server_prio, seL4_Word unused)
 {
     helper_thread_t servers[RUNS];
-    seL4_CPtr init_ep = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr init_ep = vka_alloc_donating_endpoint_leaky(&env->vka);
 
     /* first we signal to endpoint to tell the test runner we are ready */
     seL4_CPtr first_ep = endpoint;
@@ -1070,7 +1070,7 @@ static int test_stack_spawning_server(env_t env)
 {
     helper_thread_t clients[RUNS];
     helper_thread_t stack_spawner;
-    seL4_CPtr endpoint = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr endpoint = vka_alloc_donating_endpoint_leaky(&env->vka);
     ipc22_go = vka_alloc_endpoint_leaky(&env->vka);
     volatile int state = 0;
     int our_prio = 10;
@@ -1149,8 +1149,8 @@ static int test_delete_reply_cap_sc(env_t env)
 {
     helper_thread_t client, server;
     volatile int state = 0;
-    seL4_CPtr client_ep = vka_alloc_endpoint_leaky(&env->vka);
-    seL4_CPtr server_ep = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr client_ep = vka_alloc_donating_endpoint_leaky(&env->vka);
+    seL4_CPtr server_ep = vka_alloc_donating_endpoint_leaky(&env->vka);
 
     create_helper_thread(env, &client);
     create_helper_thread(env, &server);
@@ -1193,8 +1193,8 @@ static int test_delete_reply_cap_then_sc(env_t env)
     helper_thread_t client, server;
     volatile int state = 0;
 
-    seL4_CPtr client_ep = vka_alloc_endpoint_leaky(&env->vka);
-    seL4_CPtr server_ep = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr client_ep = vka_alloc_donating_endpoint_leaky(&env->vka);
+    seL4_CPtr server_ep = vka_alloc_donating_endpoint_leaky(&env->vka);
 
     create_helper_thread(env, &client);
     create_helper_thread(env, &server);
@@ -1257,7 +1257,7 @@ static int
 test_sched_donation_low_prio_server(env_t env)
 {
     helper_thread_t client, server, server2;
-    seL4_CPtr ep = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr ep = vka_alloc_donating_endpoint_leaky(&env->vka);
 
     create_helper_thread(env, &client);
     create_helper_thread(env, &server);
@@ -1324,7 +1324,7 @@ static int ipc28_client_fn(seL4_CPtr ep, volatile int *state)
 
 static int test_sched_donation_cross_core(env_t env)
 {
-    seL4_CPtr ep = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr ep = vka_alloc_donating_endpoint_leaky(&env->vka);
     helper_thread_t clients[env->cores - 1];
     helper_thread_t server;
     volatile int states[env->cores - 1];

--- a/apps/sel4test-tests/src/tests/schedcontext.c
+++ b/apps/sel4test-tests/src/tests/schedcontext.c
@@ -353,10 +353,10 @@ static void sched_context0008_server_fn(seL4_CPtr init_ep, seL4_CPtr wait_ep)
 static int test_delete_sendwait_tcb(env_t env)
 {
     helper_thread_t client, proxy, server;
-    seL4_CPtr client_send = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr client_send = vka_alloc_donating_endpoint_leaky(&env->vka);
     seL4_CPtr client_wait = vka_alloc_endpoint_leaky(&env->vka);
-    seL4_CPtr proxy_send = vka_alloc_endpoint_leaky(&env->vka);
-    seL4_CPtr server_ep = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr proxy_send = vka_alloc_donating_endpoint_leaky(&env->vka);
+    seL4_CPtr server_ep = vka_alloc_donating_endpoint_leaky(&env->vka);
 
     /* set up and start server */
     ZF_LOGD("Create server\n");
@@ -424,7 +424,7 @@ int test_sched_context_goes_to_to_caller_on_reply_cap_delete(env_t env)
     int prev_state = state;
     int error;
 
-    ep = vka_alloc_endpoint_leaky(&env->vka);
+    ep = vka_alloc_donating_endpoint_leaky(&env->vka);
     test_neq(ep, (seL4_CPtr) seL4_CapNull);
 
     reply = vka_alloc_reply_leaky(&env->vka);
@@ -477,7 +477,7 @@ int test_sched_context_unbind_server(env_t env)
     volatile int state = 0;
     int prev_state = state;
 
-    seL4_CPtr ep = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr ep = vka_alloc_donating_endpoint_leaky(&env->vka);
     test_neq(ep, (seL4_CPtr) seL4_CapNull);
 
     seL4_CPtr reply = vka_alloc_reply_leaky(&env->vka);
@@ -539,8 +539,8 @@ int test_revoke_reply_on_call_chain_returns_sc(env_t env)
     volatile int state = 0;
     int error;
 
-    seL4_CPtr ep = vka_alloc_endpoint_leaky(&env->vka);
-    seL4_CPtr ep2 = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr ep = vka_alloc_donating_endpoint_leaky(&env->vka);
+    seL4_CPtr ep2 = vka_alloc_donating_endpoint_leaky(&env->vka);
     seL4_CPtr proxy_reply = vka_alloc_reply_leaky(&env->vka);
     seL4_CPtr server_reply = vka_alloc_reply_leaky(&env->vka);
 
@@ -588,8 +588,8 @@ test_revoke_reply_on_call_chain_unordered(env_t env)
     volatile int state = 0;
     int error;
 
-    seL4_CPtr ep = vka_alloc_endpoint_leaky(&env->vka);
-    seL4_CPtr ep2 = vka_alloc_endpoint_leaky(&env->vka);
+    seL4_CPtr ep = vka_alloc_donating_endpoint_leaky(&env->vka);
+    seL4_CPtr ep2 = vka_alloc_donating_endpoint_leaky(&env->vka);
     seL4_CPtr proxy_reply = vka_alloc_reply_leaky(&env->vka);
     seL4_CPtr server_reply = vka_alloc_reply_leaky(&env->vka);
 


### PR DESCRIPTION
With the donating endpoints change in seL4 donation will only accross
endpoints explicitly designated as donating. This allows servers to be
protected from the case where a sender opts not to donate their SC when
invoking the endpoint.